### PR TITLE
fix: Remove disabled `bottle :unneeded`

### DIFF
--- a/Formula/rollout-cli.rb
+++ b/Formula/rollout-cli.rb
@@ -6,7 +6,6 @@ class RolloutCli < Formula
   desc "Publish your articles everywhere"
   homepage ""
   version "0.0.7"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/pjeziorowski/rollout/releases/download/v0.0.7/rollout_0.0.7_darwin_amd64.tar.gz"


### PR DESCRIPTION
Fixes #1 - which has since progressed to:
 
```bash
Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/pjeziorowski/homebrew-rollout-cli/Formula/rollout-cli.rb
rollout-cli: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the pjeziorowski/rollout-cli tap (not Homebrew/brew or Homebrew/core):
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/pjeziorowski/homebrew-rollout-cli/Formula/rollout-cli.rb:9

Error: Cannot tap pjeziorowski/rollout-cli: invalid syntax in tap!
```

Confirmed working on KDE neon (Ubuntu 20.04) with:

```bash
brew tap DDDominuXXX/homebrew-rollout-cli
brew install rollout-cli
```